### PR TITLE
Fix LSL Timestamp Offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > This project houses the code to prompt the user in a Tkinter window, store, and process brain wave EEG data from an
 > LSL stream.
 
-### Current Version: [[4.3.0-a] - 1/31/2024](docs/changelog.md)
+### Current Version: [[4.3.1-a] - 1/31/2024](docs/changelog.md)
 
 ## Download & Install
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.1-a] - 1/31/2024
+
+### Fixed
+- Timestamps derived from LSL stream now match up to system time using an updated offset from pylsl.
+  - The precision of these estimates should be below 1 ms (empirically within +/-0.2 ms).
+
 ## [4.3.0-a] - 1/31/2024
 
 ### Added

--- a/tests/TestThread.py
+++ b/tests/TestThread.py
@@ -42,7 +42,7 @@ class TestThread(threading.Thread):
 
         LSL.start_collection()  # Start LSL collection
 
-        sleep(config.DATA_PADDING_DURATION)  # TODO verify that this works since things are on separate threads
+        sleep(config.DATA_PADDING_DURATION)
 
         LSL.start_label(self.name)
 


### PR DESCRIPTION
## [4.3.1-a] - 1/31/2024

### Fixed
- Timestamps derived from LSL stream now match up to system time using an updated offset from pylsl.
  - The precision of these estimates should be below 1 ms (empirically within +/-0.2 ms).

## Testing
When reviewing this PR, please test and look up the timestamps to be sure it's accurate.