### PR TITLE
v1.3.0-b - Various Bug Fixes/Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ csv_downloads/*
 __pycache__/
 venv/
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The Data Collector is a graphical user interface to record participant EEG data. A researcher will run tests that prompt the participant to imagine motor impulses using audiovisual cues. The data from the OpenBCI LSL stream will be recorded, labeled, and saved to a folder hierarchy of all participants, sessions, and trials after a manual visual confirmation by the researcher.
 
-### Current Version: [[1.2.1-b] - 4/9/2024](docs/changelog.md)
+### Current Version: [[1.3.0-b] - 4/14/2024](docs/changelog.md)
 
 ## Download & Install
 

--- a/config.py
+++ b/config.py
@@ -23,6 +23,7 @@ CONSTANT_TEST_BREAK = 5      # How long to break for during constant tests (defa
 #
 # The main list of all tests corresponding to type and their images.
 #
+# TODO set up a better list of tests with auditory stimulus config, etc.
 TESTS = {
     "Transition": {
         "Stationary Float to Select": ["Stop.png", "Select.png"],
@@ -49,9 +50,6 @@ TESTS = {
         "Blink"
     ]
 }
-
-# Subject information
-NUMBER_OF_SUBJECTS = 10 #Is there a limit to amount of subjects?
 
 # Save path configuration (<DATA_PATH>/PXXX/SXXX/trial_XX/<STREAM_TYPE>_data.csv)
 SAVED_DATA_PATH = "csv_downloads"

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ SUPPORTED_STREAMS = {           # Which streams to enable/data to collect
 }
 DEFAULT_LABEL = "No Event"
 
-# Test length
+# Test length TODO add a simple equation or something to describe test durations
 DATA_PADDING_DURATION = 5    # How long to wait before starting and ending a test (default 5 seconds)
 BLINK_MIN_INTERVAL = 2.5     # The minimum duration between intervals (default 2.5 seconds)
 BLINK_MAX_INTERVAL = 6       # The maximum duration between intervals (default 6 seconds)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0-b] - 4/14/2024
+
+### Added
+- Added audio cues to eye tests.
+
+### Changed
+- Modified all test durations resulting in session time being reduced to around 60-90 minutes.
+- Cut eye test durations in half due to participant discomfort.
+
+### Fixed
+- Floating point random number generation causing issues in older versions of Python.
+- Fixed crashing on exit if no tests have been ran.
+
 ## [1.2.1-b] - 4/9/2024
 
 ### Changed

--- a/tests/BlinkTest.py
+++ b/tests/BlinkTest.py
@@ -30,7 +30,7 @@ class BlinkTest(TestThread):
             self.playsound()
             self.iteration += 1
 
-            interval = random.randint(config.BLINK_MIN_INTERVAL * 1000, config.BLINK_MAX_INTERVAL * 1000)
+            interval = random.randint(int(config.BLINK_MIN_INTERVAL * 1000), int(config.BLINK_MAX_INTERVAL * 1000))
             sleep(config.PAUSE_AFTER_TEST)  # Wait extra after blinking
             LSL.stop_label()
 

--- a/tests/ConstantTest.py
+++ b/tests/ConstantTest.py
@@ -37,6 +37,10 @@ class ConstantTest(TestThread):
             self.text = TestGUI.place_text(self.name)
             self.test_job_id = TestGUI.display_window.after(3000, TestGUI.destroy_current_element)
 
+            # Play auditory stimulus for eyes test TODO find a way to toggle auditory stimulus in config
+            if "eyes" in self.name.lower():
+                self.playsound()
+
             def resume():
                 """
                 Resumes the test after a labeling buffer for the specified duration.

--- a/tests/TestGUI.py
+++ b/tests/TestGUI.py
@@ -325,7 +325,11 @@ class TestGUI:
         """
         Helper function that handles the exit behavior of the GUI.
         """
-        state_save_path = os.path.join(config.SAVED_DATA_PATH, TestGUI.participant_ID, TestGUI.session_ID, "test_states.json")
+        # Create save path if it doesn't exist
+        state_save_path = os.path.join(config.SAVED_DATA_PATH, TestGUI.participant_ID, TestGUI.session_ID)
+        if not os.path.exists(state_save_path):
+            os.makedirs(state_save_path)
+        state_save_path = os.path.join(state_save_path, "test_states.json")
 
         # Remove GUI-specific data (lambda, button) from subkeys
         keys_to_remove = ['button', 'lambda']

--- a/tests/TestThread.py
+++ b/tests/TestThread.py
@@ -50,8 +50,8 @@ class TestThread(threading.Thread):
         """
         # If eyes test, cut transition duration in half
         if "eyes" in self.name.lower():
-            config.TRANSITION_DURATION /= 2
-            config.CONSTANT_TEST_DURATION /= 2
+            config.TRANSITION_DURATION = int(config.TRANSITION_DURATION / 2)
+            config.CONSTANT_TEST_DURATION = int(config.CONSTANT_TEST_DURATION / 2)
 
         TestGUI.start_test(self)
 
@@ -90,7 +90,7 @@ class TestThread(threading.Thread):
 
         # Restore durations if they were modified
         config.TRANSITION_DURATION = self.transition_duration
-        config.CURRENT_TEST = self.constant_duration
+        config.CONSTANT_TEST_DURATION = self.constant_duration
 
         if not complete:  # If test is not complete
             TestGUI.tests[self.name]["trial"] += 1  # Increase trial number OUTSIDE OF THREAD!!!

--- a/tests/TestThread.py
+++ b/tests/TestThread.py
@@ -34,6 +34,10 @@ class TestThread(threading.Thread):
         self.running = True
         self.test_job_id = None
 
+        # Hold values here as well incase durations need to be modified
+        self.transition_duration = config.TRANSITION_DURATION
+        self.constant_duration = config.CONSTANT_TEST_DURATION
+
         # Setup beep using pygame
         mixer.init()
         self.sound = mixer.Sound(os.path.join(os.path.dirname(__file__), '..', 'assets', 'beep.mp3'))
@@ -44,6 +48,11 @@ class TestThread(threading.Thread):
         """
         All logic related to the control panel, starting collection, and calling the stop method after a certain duration.
         """
+        # If eyes test, cut transition duration in half
+        if "eyes" in self.name.lower():
+            config.TRANSITION_DURATION /= 2
+            config.CONSTANT_TEST_DURATION /= 2
+
         TestGUI.start_test(self)
 
         print(f"Starting test {self.name}: Trial {self.trial_number}")
@@ -78,6 +87,10 @@ class TestThread(threading.Thread):
         # Log finalized test status
         print(f"{current_test} - Trial {TestGUI.tests[current_test]['trial']}: "
               f"{'Complete' if complete else 'Discarded'}")
+
+        # Restore durations if they were modified
+        config.TRANSITION_DURATION = self.transition_duration
+        config.CURRENT_TEST = self.constant_duration
 
         if not complete:  # If test is not complete
             TestGUI.tests[self.name]["trial"] += 1  # Increase trial number OUTSIDE OF THREAD!!!


### PR DESCRIPTION
## [1.3.0-b] - 4/14/2024

### Added
- Added audio cues to eye tests.

### Changed
- Modified all test durations resulting in session time being reduced to around 60-90 minutes.
- Cut eye test durations in half due to participant discomfort.

### Fixed
- Floating point random number generation causing issues in older versions of Python.
- Fixed crashing on exit if no tests have been ran.
